### PR TITLE
chore: remove @types/rimraf

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,17 @@
 {
   "name": "@villedemontreal/general-utils",
-  "version": "5.17.0",
+  "version": "5.17.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@villedemontreal/general-utils",
-      "version": "5.17.0",
+      "version": "5.17.2",
       "license": "MIT",
       "dependencies": {
         "@types/app-root-path": "1.2.6",
         "@types/lodash": "4.14.199",
         "@types/luxon": "3.3.2",
-        "@types/rimraf": "4.0.5",
         "app-root-path": "3.1.0",
         "get-port": "5.1.1",
         "globby": "13.2.2",
@@ -567,15 +566,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.57.tgz",
       "integrity": "sha512-piPoDozdPaX1hNWFJQzzgWqE40gh986VvVx/QO9RU4qYRE55ld7iepDVgZ3ccGUw0R4wge0Oy1dd+3xOQNkkUQ==",
       "dev": true
-    },
-    "node_modules/@types/rimraf": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@types/rimraf/-/rimraf-4.0.5.tgz",
-      "integrity": "sha512-DTCZoIQotB2SUJnYgrEx43cQIUYOlNZz0AZPbKU4PSLYTUdML5Gox0++z4F9kQocxStrCmRNhi4x5x/UlwtKUA==",
-      "deprecated": "This is a stub types definition. rimraf provides its own type definitions, so you do not need this installed.",
-      "dependencies": {
-        "rimraf": "*"
-      }
     },
     "node_modules/@types/sinon": {
       "version": "10.0.18",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@villedemontreal/general-utils",
-  "version": "5.17.1",
+  "version": "5.17.2",
   "description": "General utilities library",
   "main": "dist/src/index.js",
   "engines": {
@@ -41,7 +41,6 @@
     "@types/app-root-path": "1.2.6",
     "@types/lodash": "4.14.199",
     "@types/luxon": "3.3.2",
-    "@types/rimraf": "4.0.5",
     "app-root-path": "3.1.0",
     "get-port": "5.1.1",
     "globby": "13.2.2",


### PR DESCRIPTION
rimraf provides its own type definitions, so you don't need @types/rimraf installed!

causing conflict with rimraf defs


